### PR TITLE
Fix inserting graph nodes with multiple dependents

### DIFF
--- a/bindings/swift/Arbiter/Graph.swift
+++ b/bindings/swift/Arbiter/Graph.swift
@@ -43,11 +43,11 @@ public final class ResolvedDependencyGraph<ProjectValue: ArbiterValue, VersionMe
     return ResolvedDependencyGraph(ptr, shouldCopy: false)
   }
 
-  public func addRoot (node: ResolvedDependency<ProjectValue, VersionMetadata>, requirement: Requirement) throws
+  public func addNode (node: ResolvedDependency<ProjectValue, VersionMetadata>, requirement: Requirement) throws
   {
     var cStr: UnsafeMutablePointer<CChar> = nil
 
-    if (!ArbiterResolvedDependencyGraphAddRoot(pointer, node.pointer, requirement.pointer, &cStr)) {
+    if (!ArbiterResolvedDependencyGraphAddNode(pointer, node.pointer, requirement.pointer, &cStr)) {
       let string = String(UTF8String: cStr)
       free(cStr)
 
@@ -59,7 +59,7 @@ public final class ResolvedDependencyGraph<ProjectValue: ArbiterValue, VersionMe
   {
     var cStr: UnsafeMutablePointer<CChar> = nil
 
-    if (!ArbiterResolvedDependencyGraphAddEdge(pointer, dependent.pointer, dependency.pointer, requirement.pointer, &cStr)) {
+    if (!ArbiterResolvedDependencyGraphAddEdge(pointer, dependent.pointer, dependency.pointer, &cStr)) {
       let string = String(UTF8String: cStr)
       free(cStr)
 

--- a/include/arbiter/Graph.h
+++ b/include/arbiter/Graph.h
@@ -45,7 +45,7 @@ ArbiterResolvedDependencyGraph *ArbiterResolvedDependencyGraphCreate (void);
 ArbiterResolvedDependencyGraph *ArbiterResolvedDependencyGraphCopyWithNewRoots (const ArbiterResolvedDependencyGraph *baseGraph, const struct ArbiterProjectIdentifier * const *roots, size_t rootCount);
 
 /**
- * Attempts to add a root node into the dependency graph, without making it
+ * Attempts to add a node into the dependency graph, without making it
  * inconsistent.
  *
  * If the given dependency refers to a project which already exists in the
@@ -55,20 +55,20 @@ ArbiterResolvedDependencyGraph *ArbiterResolvedDependencyGraphCopyWithNewRoots (
  * not NULL, it may be set to a string describing the error, which the caller is
  * responsible for freeing.
  */
-bool ArbiterResolvedDependencyGraphAddRoot (ArbiterResolvedDependencyGraph *graph, const struct ArbiterResolvedDependency *node, const struct ArbiterRequirement *requirement, char **error);
+bool ArbiterResolvedDependencyGraphAddNode (ArbiterResolvedDependencyGraph *graph, const struct ArbiterResolvedDependency *node, const struct ArbiterRequirement *requirement, char **error);
 
 /**
- * Attempts to add an edge (dependency relationship) into the dependency graph,
- * from `dependent` to `dependency`, without making it inconsistent.
+ * Adds an edge (dependency relationship) into the dependency graph, from
+ * `dependent` to `dependency`.
  *
- * If `dependency` refers to a project which already exists in the graph, this
- * will attempt to intersect the version requirements of both.
+ * This must only be called after both projects have already been inserted into
+ * the graph with ArbiterResolvedDependencyGraphAddNode().
  *
  * Returns whether the addition succeeded. If `false` is returned and `error` is
  * not NULL, it may be set to a string describing the error, which the caller is
  * responsible for freeing.
  */
-bool ArbiterResolvedDependencyGraphAddEdge (ArbiterResolvedDependencyGraph *graph, const struct ArbiterProjectIdentifier *dependent, const struct ArbiterResolvedDependency *dependency, const struct ArbiterRequirement *requirement, char **error);
+bool ArbiterResolvedDependencyGraphAddEdge (ArbiterResolvedDependencyGraph *graph, const struct ArbiterProjectIdentifier *dependent, const struct ArbiterProjectIdentifier *dependency, char **error);
 
 /**
  * Returns the number of unique nodes in the given graph, for use with

--- a/src/Graph.h
+++ b/src/Graph.h
@@ -46,15 +46,22 @@ struct ArbiterResolvedDependencyGraph final : public Arbiter::Base
     using EdgeMap = std::unordered_map<NodeKey, std::set<NodeKey>>;
 
     /**
-     * Attempts to add the given node into the graph, as a dependency of
-     * `dependent` if specified.
+     * Attempts to add the given node into the graph.
      *
      * If the given node refers to a project which already exists in the graph,
      * this method will attempt to intersect the version requirements of both.
      *
      * Throws an exception if this addition would make the graph inconsistent.
      */
-    void addNode (ArbiterResolvedDependency node, const ArbiterRequirement &initialRequirement, const Arbiter::Optional<NodeKey> &dependent) noexcept(false);
+    void addNode (ArbiterResolvedDependency node, const ArbiterRequirement &initialRequirement) noexcept(false);
+
+    /**
+     * Adds an edge from a dependent to its dependency.
+     *
+     * Both sides of the edge must have already been added to the graph with
+     * addNode().
+     */
+    void addEdge (const ArbiterProjectIdentifier &dependent, ArbiterProjectIdentifier dependency);
 
     const NodeMap &nodes () const
     {

--- a/src/Optional.h
+++ b/src/Optional.h
@@ -8,6 +8,7 @@
 
 #include <cassert>
 #include <functional>
+#include <ostream>
 #include <type_traits>
 
 namespace Arbiter {
@@ -266,5 +267,15 @@ struct hash<Arbiter::Optional<T>> final
       }
     }
 };
+
+template<typename T>
+std::ostream &operator<< (std::ostream &os, const Arbiter::Optional<T> &optional)
+{
+  if (optional) {
+    return os << "Optional(" << *optional << ")";
+  } else {
+    return os << "None";
+  }
+}
 
 } // namespace std

--- a/test/ResolverTest.cpp
+++ b/test/ResolverTest.cpp
@@ -223,7 +223,7 @@ TEST(ResolverTest, ResolvesIncrementallyFromInitialGraph)
   auto resolvedA = ArbiterResolvedDependency(makeProjectIdentifier("A"), ArbiterSelectedVersion(ArbiterSemanticVersion(2, 3, 4), makeSharedUserValue<ArbiterSelectedVersion, EmptyTestValue>()));
 
   ArbiterResolvedDependencyGraph initialGraph;
-  initialGraph.addNode(std::move(resolvedA), Requirement::AtLeast(ArbiterSemanticVersion(2, 0, 1)), None());
+  initialGraph.addNode(std::move(resolvedA), Requirement::AtLeast(ArbiterSemanticVersion(2, 0, 1)));
 
   std::vector<ArbiterDependency> dependencies;
   dependencies.emplace_back(makeProjectIdentifier("B"), Requirement::CompatibleWith(ArbiterSemanticVersion(2, 0, 0), ArbiterRequirementStrictnessStrict));


### PR DESCRIPTION
This was the cause of build order failures in https://github.com/ArbiterLib/Carthage/pull/1. We would insert nodes into the graph, but omit some of their dependents (reverse edges) because of how the API is structured.

Carthage didn't have this problem because it would only be processing one dependent at a time, but we could've come from multiple due to how transitives are collected "breadth-first."