### PR TITLE
Use instantiations instead of versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GTEST_DIR ?= external/googletest/googletest
 CXX ?= clang++
-CXXFLAGS += -std=c++14 -pedantic -Wall -Wextra -Iinclude/
+CXXFLAGS += -std=c++14 -pedantic -Wall -Wextra -Iinclude/ -Isrc/
 CC ?= clang
 CFLAGS += -std=c99 -pedantic -Wall -Wextra -Wno-unused-parameter -Iinclude/
 AR ?= ar

--- a/bindings/swift/Arbiter.xcodeproj/project.pbxproj
+++ b/bindings/swift/Arbiter.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		351C4E5F1D96619F00905E1F /* Graph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351C4E5E1D96619F00905E1F /* Graph.swift */; };
 		351C4E611D9662A300905E1F /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351C4E601D9662A300905E1F /* Errors.swift */; };
 		357FB07F1D75AF6A0040691B /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357FB07E1D75AF6A0040691B /* Resolver.swift */; };
+		D042D2AC1DBD10E500E4A9E5 /* Project.h in Headers */ = {isa = PBXBuildFile; fileRef = D042D2AB1DBD10E500E4A9E5 /* Project.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D09B693A1D84600E00BDD4A4 /* OnDemandCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09B69391D84600E00BDD4A4 /* OnDemandCollection.swift */; };
 		D0DB8C061D74937A003657D3 /* Arbiter.h in Headers */ = {isa = PBXBuildFile; fileRef = D0DB8C051D74937A003657D3 /* Arbiter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0F65B341D7493E800DD582F /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F65B331D7493E800DD582F /* Version.swift */; };
@@ -42,6 +43,7 @@
 		351C4E5E1D96619F00905E1F /* Graph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.swift; sourceTree = "<group>"; };
 		351C4E601D9662A300905E1F /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		357FB07E1D75AF6A0040691B /* Resolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
+		D042D2AB1DBD10E500E4A9E5 /* Project.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Project.h; path = ../../../include/arbiter/Project.h; sourceTree = "<group>"; };
 		D09B69391D84600E00BDD4A4 /* OnDemandCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnDemandCollection.swift; sourceTree = "<group>"; };
 		D0DB8C021D74937A003657D3 /* Arbiter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Arbiter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0DB8C051D74937A003657D3 /* Arbiter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Arbiter.h; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 				D0DB8C051D74937A003657D3 /* Arbiter.h */,
 				D0F65B441D7496AE00DD582F /* Dependency.h */,
 				351C4E5C1D96619600905E1F /* Graph.h */,
+				D042D2AB1DBD10E500E4A9E5 /* Project.h */,
 				D0F65B451D7496AE00DD582F /* Requirement.h */,
 				D0F65B461D7496AE00DD582F /* Resolver.h */,
 				D0F8619D1D74DFA1009BD4C6 /* Types.h */,
@@ -149,6 +152,7 @@
 				D0DB8C061D74937A003657D3 /* Arbiter.h in Headers */,
 				D0F65B491D7496AE00DD582F /* Dependency.h in Headers */,
 				D0F65B4A1D7496AE00DD582F /* Requirement.h in Headers */,
+				D042D2AC1DBD10E500E4A9E5 /* Project.h in Headers */,
 				D0F65B4B1D7496AE00DD582F /* Resolver.h in Headers */,
 				D0F8619E1D74DFA1009BD4C6 /* Types.h in Headers */,
 				D0F65B4C1D7496AE00DD582F /* Value.h in Headers */,

--- a/bindings/swift/Arbiter.xcodeproj/project.pbxproj
+++ b/bindings/swift/Arbiter.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		351C4E611D9662A300905E1F /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351C4E601D9662A300905E1F /* Errors.swift */; };
 		357FB07F1D75AF6A0040691B /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357FB07E1D75AF6A0040691B /* Resolver.swift */; };
 		D042D2AC1DBD10E500E4A9E5 /* Project.h in Headers */ = {isa = PBXBuildFile; fileRef = D042D2AB1DBD10E500E4A9E5 /* Project.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D08125AC1DBD22FA00EE3D05 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08125AB1DBD22FA00EE3D05 /* Project.swift */; };
 		D09B693A1D84600E00BDD4A4 /* OnDemandCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09B69391D84600E00BDD4A4 /* OnDemandCollection.swift */; };
 		D0DB8C061D74937A003657D3 /* Arbiter.h in Headers */ = {isa = PBXBuildFile; fileRef = D0DB8C051D74937A003657D3 /* Arbiter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0F65B341D7493E800DD582F /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F65B331D7493E800DD582F /* Version.swift */; };
@@ -44,6 +45,7 @@
 		351C4E601D9662A300905E1F /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		357FB07E1D75AF6A0040691B /* Resolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
 		D042D2AB1DBD10E500E4A9E5 /* Project.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Project.h; path = ../../../include/arbiter/Project.h; sourceTree = "<group>"; };
+		D08125AB1DBD22FA00EE3D05 /* Project.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 		D09B69391D84600E00BDD4A4 /* OnDemandCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnDemandCollection.swift; sourceTree = "<group>"; };
 		D0DB8C021D74937A003657D3 /* Arbiter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Arbiter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0DB8C051D74937A003657D3 /* Arbiter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Arbiter.h; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 				351C4E601D9662A300905E1F /* Errors.swift */,
 				351C4E5E1D96619F00905E1F /* Graph.swift */,
 				D09B69391D84600E00BDD4A4 /* OnDemandCollection.swift */,
+				D08125AB1DBD22FA00EE3D05 /* Project.swift */,
 				D0F861A51D74EBB2009BD4C6 /* Requirement.swift */,
 				357FB07E1D75AF6A0040691B /* Resolver.swift */,
 				D0F8619F1D74E0D9009BD4C6 /* Types.swift */,
@@ -254,6 +257,7 @@
 				351C4E5F1D96619F00905E1F /* Graph.swift in Sources */,
 				D0F65B341D7493E800DD582F /* Version.swift in Sources */,
 				D0F861A61D74EBB2009BD4C6 /* Requirement.swift in Sources */,
+				D08125AC1DBD22FA00EE3D05 /* Project.swift in Sources */,
 				D0F861A01D74E0D9009BD4C6 /* Types.swift in Sources */,
 				D09B693A1D84600E00BDD4A4 /* OnDemandCollection.swift in Sources */,
 				357FB07F1D75AF6A0040691B /* Resolver.swift in Sources */,

--- a/bindings/swift/Arbiter/Arbiter.h
+++ b/bindings/swift/Arbiter/Arbiter.h
@@ -8,6 +8,7 @@ FOUNDATION_EXPORT const unsigned char ArbiterVersionString[];
 
 #import <Arbiter/Dependency.h>
 #import <Arbiter/Graph.h>
+#import <Arbiter/Project.h>
 #import <Arbiter/Requirement.h>
 #import <Arbiter/Resolver.h>
 #import <Arbiter/Types.h>

--- a/bindings/swift/Arbiter/Dependency.swift
+++ b/bindings/swift/Arbiter/Dependency.swift
@@ -1,22 +1,3 @@
-public final class ProjectIdentifier<Value: ArbiterValue> : CObject
-{
-  public override init (_ pointer: COpaquePointer, shouldCopy: Bool = true)
-  {
-    super.init(pointer, shouldCopy: shouldCopy)
-  }
-
-  public convenience init (value: Value)
-  {
-    let ptr = ArbiterCreateProjectIdentifier(value.toUserValue())
-    self.init(ptr, shouldCopy: false)
-  }
-
-  public var value: Value
-  {
-    return Value.fromUserValue(ArbiterProjectIdentifierValue(pointer))
-  }
-}
-
 public final class Dependency<ProjectValue: ArbiterValue> : CObject
 {
   public override init (_ pointer: COpaquePointer, shouldCopy: Bool = true)

--- a/bindings/swift/Arbiter/Project.swift
+++ b/bindings/swift/Arbiter/Project.swift
@@ -1,0 +1,19 @@
+public final class ProjectIdentifier<Value: ArbiterValue> : CObject
+{
+  public override init (_ pointer: COpaquePointer, shouldCopy: Bool = true)
+  {
+    super.init(pointer, shouldCopy: shouldCopy)
+  }
+
+  public convenience init (value: Value)
+  {
+    let ptr = ArbiterCreateProjectIdentifier(value.toUserValue())
+    self.init(ptr, shouldCopy: false)
+  }
+
+  public var value: Value
+  {
+    return Value.fromUserValue(ArbiterProjectIdentifierValue(pointer))
+  }
+}
+

--- a/examples/library_folders/dependencies.h
+++ b/examples/library_folders/dependencies.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <arbiter/Dependency.h>
+#include <arbiter/Project.h>
 #include <arbiter/Resolver.h>
 #include <arbiter/Version.h>
 

--- a/include/arbiter/Dependency.h
+++ b/include/arbiter/Dependency.h
@@ -5,34 +5,12 @@
 extern "C" {
 #endif
 
-#include <arbiter/Value.h>
-
 #include <stddef.h>
 
 // forward declarations
+struct ArbiterProjectIdentifier;
 struct ArbiterRequirement;
 struct ArbiterSelectedVersion;
-
-/**
- * An opaque value which identifies a project participating in dependency
- * resolution.
- */
-typedef struct ArbiterProjectIdentifier ArbiterProjectIdentifier;
-
-/**
- * Creates a project identifier from the given opaque data.
- *
- * The returned identifier must be freed with ArbiterFree().
- */
-ArbiterProjectIdentifier *ArbiterCreateProjectIdentifier (ArbiterUserValue value);
-
-/**
- * Returns the opaque data which was provided to ArbiterCreateProjectIdentifier().
- *
- * The returned pointer is only guaranteed to remain valid for the current
- * scope.
- */
-const void *ArbiterProjectIdentifierValue (const ArbiterProjectIdentifier *projectIdentifier);
 
 /**
  * Represents a dependency specification, which consists of a project identifier
@@ -46,7 +24,7 @@ typedef struct ArbiterDependency ArbiterDependency;
  *
  * The returned dependency must be freed with ArbiterFree().
  */
-ArbiterDependency *ArbiterCreateDependency (const ArbiterProjectIdentifier *projectIdentifier, const struct ArbiterRequirement *requirement);
+ArbiterDependency *ArbiterCreateDependency (const struct ArbiterProjectIdentifier *projectIdentifier, const struct ArbiterRequirement *requirement);
 
 /**
  * Returns the project identified by this dependency. 
@@ -54,7 +32,7 @@ ArbiterDependency *ArbiterCreateDependency (const ArbiterProjectIdentifier *proj
  * The returned pointer is only guaranteed to remain valid for the current
  * scope.
  */
-const ArbiterProjectIdentifier *ArbiterDependencyProject (const ArbiterDependency *dependency);
+const struct ArbiterProjectIdentifier *ArbiterDependencyProject (const ArbiterDependency *dependency);
 
 /**
  * Returns the version requirement of this dependency. 
@@ -89,7 +67,7 @@ typedef struct ArbiterResolvedDependency ArbiterResolvedDependency;
  *
  * The returned dependency must be freed with ArbiterFree().
  */
-ArbiterResolvedDependency *ArbiterCreateResolvedDependency (const ArbiterProjectIdentifier *project, const struct ArbiterSelectedVersion *version);
+ArbiterResolvedDependency *ArbiterCreateResolvedDependency (const struct ArbiterProjectIdentifier *project, const struct ArbiterSelectedVersion *version);
 
 /**
  * Returns the project this resolved dependency refers to.

--- a/include/arbiter/Dependency.h
+++ b/include/arbiter/Dependency.h
@@ -75,7 +75,7 @@ ArbiterResolvedDependency *ArbiterCreateResolvedDependency (const struct Arbiter
  * The returned pointer is only guaranteed to remain valid for the current
  * scope.
  */
-const ArbiterProjectIdentifier *ArbiterResolvedDependencyProject (const ArbiterResolvedDependency *dependency);
+const struct ArbiterProjectIdentifier *ArbiterResolvedDependencyProject (const ArbiterResolvedDependency *dependency);
 
 /**
  * Returns the version which was selected for this resolved dependency.

--- a/include/arbiter/Project.h
+++ b/include/arbiter/Project.h
@@ -1,0 +1,35 @@
+#ifndef ARBITER_PROJECT_H
+#define ARBITER_PROJECT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <arbiter/Value.h>
+
+/**
+ * An opaque value which identifies a project participating in dependency
+ * resolution.
+ */
+typedef struct ArbiterProjectIdentifier ArbiterProjectIdentifier;
+
+/**
+ * Creates a project identifier from the given opaque data.
+ *
+ * The returned identifier must be freed with ArbiterFree().
+ */
+ArbiterProjectIdentifier *ArbiterCreateProjectIdentifier (ArbiterUserValue value);
+
+/**
+ * Returns the opaque data which was provided to ArbiterCreateProjectIdentifier().
+ *
+ * The returned pointer is only guaranteed to remain valid for the current
+ * scope.
+ */
+const void *ArbiterProjectIdentifierValue (const ArbiterProjectIdentifier *projectIdentifier);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -7,16 +7,6 @@
 
 using namespace Arbiter;
 
-ArbiterProjectIdentifier *ArbiterCreateProjectIdentifier (ArbiterUserValue value)
-{
-  return new ArbiterProjectIdentifier(ArbiterProjectIdentifier::Value(value));
-}
-
-const void *ArbiterProjectIdentifierValue (const ArbiterProjectIdentifier *projectIdentifier)
-{
-  return projectIdentifier->_value.data();
-}
-
 ArbiterDependency *ArbiterCreateDependency (const ArbiterProjectIdentifier *projectIdentifier, const ArbiterRequirement *requirement)
 {
   return new ArbiterDependency(*projectIdentifier, *requirement);
@@ -57,26 +47,6 @@ const ArbiterProjectIdentifier *ArbiterResolvedDependencyProject (const ArbiterR
 const ArbiterSelectedVersion *ArbiterResolvedDependencyVersion (const ArbiterResolvedDependency *dependency)
 {
   return &dependency->_version;
-}
-
-std::unique_ptr<Base> ArbiterProjectIdentifier::clone () const
-{
-  return std::make_unique<ArbiterProjectIdentifier>(*this);
-}
-
-std::ostream &ArbiterProjectIdentifier::describe (std::ostream &os) const
-{
-  return os << "ArbiterProjectIdentifier(" << _value << ")";
-}
-
-bool ArbiterProjectIdentifier::operator== (const Arbiter::Base &other) const
-{
-  auto ptr = dynamic_cast<const ArbiterProjectIdentifier *>(&other);
-  if (!ptr) {
-    return false;
-  }
-
-  return _value == ptr->_value;
 }
 
 ArbiterDependency::ArbiterDependency (ArbiterProjectIdentifier projectIdentifier, const ArbiterRequirement &requirement)
@@ -164,11 +134,6 @@ bool ArbiterResolvedDependency::operator== (const Arbiter::Base &other) const
 bool ArbiterResolvedDependency::operator< (const ArbiterResolvedDependency &other) const
 {
   return _project < other._project;
-}
-
-size_t std::hash<ArbiterProjectIdentifier>::operator() (const ArbiterProjectIdentifier &project) const
-{
-  return hashOf(project._value);
 }
 
 size_t std::hash<ArbiterDependency>::operator() (const ArbiterDependency &dependency) const

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -7,6 +7,7 @@
 #include <arbiter/Dependency.h>
 
 #include "Optional.h"
+#include "Project.h"
 #include "Requirement.h"
 #include "Types.h"
 #include "Value.h"
@@ -19,30 +20,6 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <vector>
-
-struct ArbiterProjectIdentifier final : public Arbiter::Base
-{
-  public:
-    using Value = Arbiter::SharedUserValue<ArbiterProjectIdentifier>;
-
-    Value _value;
-
-    ArbiterProjectIdentifier ()
-    {}
-
-    explicit ArbiterProjectIdentifier (Value value)
-      : _value(std::move(value))
-    {}
-
-    std::unique_ptr<Arbiter::Base> clone () const override;
-    std::ostream &describe (std::ostream &os) const override;
-    bool operator== (const Arbiter::Base &other) const override;
-
-    bool operator< (const ArbiterProjectIdentifier &other) const
-    {
-      return _value < other._value;
-    }
-};
 
 struct ArbiterDependency final : public Arbiter::Base
 {

--- a/src/Exception.h
+++ b/src/Exception.h
@@ -13,7 +13,7 @@ namespace Exception {
 /**
  * Base type for Arbiter exceptions.
  */
-struct Base : std::runtime_error
+struct Base : public std::runtime_error
 {
   public:
     Base () = delete;
@@ -28,7 +28,7 @@ struct Base : std::runtime_error
  * Exception type representing an error that was returned from Arbiter client
  * code.
  */
-struct UserError final : Base
+struct UserError final : public Base
 {
   public:
     UserError ()
@@ -44,7 +44,7 @@ struct UserError final : Base
  * Exception type indicating that there were mutually exclusive constraints in
  * a proposed dependency graph.
  */
-struct MutuallyExclusiveConstraints final : Base
+struct MutuallyExclusiveConstraints final : public Base
 {
   public:
     explicit MutuallyExclusiveConstraints (const std::string &string)
@@ -56,7 +56,7 @@ struct MutuallyExclusiveConstraints final : Base
  * Exception type indicating that there were unsatisfiable constraints for the
  * selected versions in a proposed dependency graph.
  */
-struct UnsatisfiableConstraints final : Base
+struct UnsatisfiableConstraints final : public Base
 {
   public:
     explicit UnsatisfiableConstraints (const std::string &string)

--- a/src/Instantiation.cpp
+++ b/src/Instantiation.cpp
@@ -1,0 +1,53 @@
+#include "Instantiation.h"
+
+#include "Hash.h"
+#include "Requirement.h"
+
+#include <algorithm>
+
+namespace Arbiter {
+
+bool Instantiation::satisfies (const ArbiterRequirement &requirement) const
+{
+  return std::all_of(_versions.begin(), _versions.end(), [&](const ArbiterSelectedVersion &version) {
+    // If the requirement excludes this instantiation, we'll find out on the
+    // first version element, short-circuiting the rest of the enumeration.
+    return requirement.satisfiedBy(version);
+  });
+}
+
+bool Instantiation::operator== (const Instantiation &other) const
+{
+  return _dependencies == other._dependencies;
+}
+
+std::ostream &operator<< (std::ostream &os, const Instantiation &instantiation)
+{
+  os << "Instantiation {";
+  for (auto it = instantiation._versions.begin(); it != instantiation._versions.end(); ++it) {
+    if (it != instantiation._versions.begin()) {
+      os << ", ";
+    }
+
+    os << *it;
+  }
+
+  return os << "}";
+}
+
+} // namespace Arbiter
+
+namespace std {
+
+size_t std::hash<Arbiter::Instantiation>::operator() (const Arbiter::Instantiation &value) const
+{
+  size_t h = Arbiter::hashOf(value.dependencies().size());
+
+  if (!value.dependencies().empty()) {
+    h ^= Arbiter::hashOf(*value.dependencies().begin());
+  }
+
+  return h;
+}
+
+} // namespace std

--- a/src/Instantiation.h
+++ b/src/Instantiation.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#ifndef __cplusplus
+#error "This file must be compiled as C++."
+#endif
+
+#include "Dependency.h"
+#include "Version.h"
+
+#include <functional>
+#include <ostream>
+#include <unordered_set>
+
+struct ArbiterRequirement;
+
+namespace Arbiter {
+
+/**
+ * Represents an instantiation of a project in the dependency graph, across all
+ * versions of that project where the dependency requirements are _identical_.
+ *
+ * In other words, this corresponds to a set of project versions that are
+ * substitutable for each other in terms of the effect they would have upon the
+ * graph. If a particular project instantiation caused the graph to become
+ * inconsistent, we know that _all_ versions associated with that instantiation
+ * are not viable.
+ *
+ * This does not take into account constraints upon the version of the project
+ * itself, merely how it would affect further resolution.
+ */
+class Instantiation final
+{
+  public:
+    using Dependencies = std::unordered_set<ArbiterDependency>;
+    using Versions = std::set<ArbiterSelectedVersion, std::greater<ArbiterSelectedVersion>>;
+
+    explicit Instantiation (Dependencies dependencies)
+      : _dependencies(std::move(dependencies))
+    {}
+
+    const Dependencies &dependencies () const
+    {
+      return _dependencies;
+    }
+
+    /**
+     * The versions which correspond to this instantiation.
+     */
+    Versions _versions;
+
+    /**
+     * Determines whether any version within this instantiation can satisfy the
+     * specified requirement.
+     */
+    bool satisfies (const ArbiterRequirement &requirement) const;
+
+    bool operator== (const Instantiation &other) const;
+
+  private:
+    /**
+     * The set of dependencies and their constraints within this instantiation.
+     */
+    Dependencies _dependencies;
+};
+
+std::ostream &operator<< (std::ostream &os, const Instantiation &instantiation);
+
+} // namespace Arbiter
+
+namespace std {
+
+template<>
+struct hash<Arbiter::Instantiation> final
+{
+  public:
+    size_t operator() (const Arbiter::Instantiation &value) const;
+};
+
+} // namespace std

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -41,3 +41,38 @@ std::shared_ptr<Instantiation> Project::instantiationForDependencies (const std:
 }
 
 } // namespace Arbiter
+
+ArbiterProjectIdentifier *ArbiterCreateProjectIdentifier (ArbiterUserValue value)
+{
+  return new ArbiterProjectIdentifier(ArbiterProjectIdentifier::Value(value));
+}
+
+const void *ArbiterProjectIdentifierValue (const ArbiterProjectIdentifier *projectIdentifier)
+{
+  return projectIdentifier->_value.data();
+}
+
+std::unique_ptr<Arbiter::Base> ArbiterProjectIdentifier::clone () const
+{
+  return std::make_unique<ArbiterProjectIdentifier>(*this);
+}
+
+std::ostream &ArbiterProjectIdentifier::describe (std::ostream &os) const
+{
+  return os << "ArbiterProjectIdentifier(" << _value << ")";
+}
+
+bool ArbiterProjectIdentifier::operator== (const Arbiter::Base &other) const
+{
+  auto ptr = dynamic_cast<const ArbiterProjectIdentifier *>(&other);
+  if (!ptr) {
+    return false;
+  }
+
+  return _value == ptr->_value;
+}
+
+size_t std::hash<ArbiterProjectIdentifier>::operator() (const ArbiterProjectIdentifier &project) const
+{
+  return hashOf(project._value);
+}

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -1,0 +1,43 @@
+#include "Project.h"
+
+#include "Dependency.h"
+#include "Instantiation.h"
+
+#include <algorithm>
+
+namespace Arbiter {
+
+void Project::addInstantiation (const std::shared_ptr<Instantiation> &instantiation)
+{
+  // TODO: Check for duplicates?
+
+  _instantiations.emplace_back(instantiation);
+}
+
+std::shared_ptr<Instantiation> Project::instantiationForVersion (const ArbiterSelectedVersion &version) const
+{
+  auto it = std::find_if(_instantiations.begin(), _instantiations.end(), [&](const auto &instantiation) {
+    return instantiation->_versions.find(version) != instantiation->_versions.end();
+  });
+
+  if (it == _instantiations.end()) {
+    return nullptr;
+  } else {
+    return *it;
+  }
+}
+
+std::shared_ptr<Instantiation> Project::instantiationForDependencies (const std::unordered_set<ArbiterDependency> &dependencies) const
+{
+  auto it = std::find_if(_instantiations.begin(), _instantiations.end(), [&](const auto &instantiation) {
+    return instantiation->dependencies() == dependencies;
+  });
+
+  if (it == _instantiations.end()) {
+    return nullptr;
+  } else {
+    return *it;
+  }
+}
+
+} // namespace Arbiter

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -7,11 +7,18 @@
 
 namespace Arbiter {
 
-void Project::addInstantiation (const std::shared_ptr<Instantiation> &instantiation)
+std::shared_ptr<Instantiation> Project::addInstantiation (const ArbiterSelectedVersion &version, const ArbiterDependencyList &dependencyList)
 {
-  // TODO: Check for duplicates?
+  Instantiation::Dependencies dependencies(dependencyList._dependencies.begin(), dependencyList._dependencies.end());
 
-  _instantiations.emplace_back(instantiation);
+  std::shared_ptr<Instantiation> inst = instantiationForDependencies(dependencies);
+  if (!inst) {
+    inst = std::make_shared<Instantiation>(std::move(dependencies));
+    _instantiations.emplace_back(inst);
+  }
+
+  inst->_versions.emplace(version);
+  return inst;
 }
 
 std::shared_ptr<Instantiation> Project::instantiationForVersion (const ArbiterSelectedVersion &version) const

--- a/src/Project.h
+++ b/src/Project.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 struct ArbiterDependency;
+struct ArbiterDependencyList;
 
 namespace Arbiter {
 
@@ -75,7 +76,7 @@ class Project final
       return _instantiations;
     }
 
-    void addInstantiation (const std::shared_ptr<Instantiation> &instantiation);
+    std::shared_ptr<Instantiation> addInstantiation (const ArbiterSelectedVersion &version, const ArbiterDependencyList &dependencyList);
 
     std::shared_ptr<Instantiation> instantiationForVersion (const ArbiterSelectedVersion &version) const;
     std::shared_ptr<Instantiation> instantiationForDependencies (const std::unordered_set<ArbiterDependency> &dependencies) const;

--- a/src/Project.h
+++ b/src/Project.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#ifndef __cplusplus
+#error "This file must be compiled as C++."
+#endif
+
+#include "Version.h"
+
+#include <functional>
+#include <memory>
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+struct ArbiterDependency;
+
+namespace Arbiter {
+
+class Instantiation; 
+
+} // namespace Arbiter
+
+namespace Arbiter {
+
+/**
+ * Contains the growing set of information about a project during dependency
+ * resolution.
+ */
+class Project final
+{
+  public:
+    using Domain = std::set<ArbiterSelectedVersion, std::greater<ArbiterSelectedVersion>>;
+    using Instantiations = std::vector<std::shared_ptr<Instantiation>>;
+
+    explicit Project (Domain domain)
+      : _domain(std::move(domain))
+    {}
+
+    const Domain &domain () const
+    {
+      return _domain;
+    }
+
+    const Instantiations &instantiations () const
+    {
+      return _instantiations;
+    }
+
+    void addInstantiation (const std::shared_ptr<Instantiation> &instantiation);
+
+    std::shared_ptr<Instantiation> instantiationForVersion (const ArbiterSelectedVersion &version) const;
+    std::shared_ptr<Instantiation> instantiationForDependencies (const std::unordered_set<ArbiterDependency> &dependencies) const;
+
+  private:
+    /**
+     * Possible versions for this project, in preferential order.
+     */
+    Domain _domain;
+
+    /**
+     * Instantiations that have been found so far. This set will only grow over
+     * the course of resolution.
+     */
+    Instantiations _instantiations;
+};
+
+} // namespace Arbiter

--- a/src/Project.h
+++ b/src/Project.h
@@ -4,10 +4,15 @@
 #error "This file must be compiled as C++."
 #endif
 
+#include <arbiter/Project.h>
+
+#include "Types.h"
+#include "Value.h"
 #include "Version.h"
 
 #include <functional>
 #include <memory>
+#include <ostream>
 #include <set>
 #include <unordered_set>
 #include <vector>
@@ -19,6 +24,30 @@ namespace Arbiter {
 class Instantiation; 
 
 } // namespace Arbiter
+
+struct ArbiterProjectIdentifier final : public Arbiter::Base
+{
+  public:
+    using Value = Arbiter::SharedUserValue<ArbiterProjectIdentifier>;
+
+    Value _value;
+
+    ArbiterProjectIdentifier ()
+    {}
+
+    explicit ArbiterProjectIdentifier (Value value)
+      : _value(std::move(value))
+    {}
+
+    std::unique_ptr<Arbiter::Base> clone () const override;
+    std::ostream &describe (std::ostream &os) const override;
+    bool operator== (const Arbiter::Base &other) const override;
+
+    bool operator< (const ArbiterProjectIdentifier &other) const
+    {
+      return _value < other._value;
+    }
+};
 
 namespace Arbiter {
 

--- a/src/Requirement.h
+++ b/src/Requirement.h
@@ -21,6 +21,12 @@ class Visitor;
 } // namespace Requirement
 } // namespace Arbiter
 
+namespace Arbiter {
+
+class Instantiation;
+
+} // namespace Arbiter
+
 struct ArbiterRequirement : public Arbiter::Base
 {
   public:
@@ -326,6 +332,27 @@ class Prioritized final : public ArbiterRequirement
 
   private:
     int _priority;
+};
+
+class ExcludedInstantiation final : public ArbiterRequirement
+{
+  public:
+    std::shared_ptr<Instantiation> _excludedInstantiation;
+
+    explicit ExcludedInstantiation (std::shared_ptr<Instantiation> excludedInstantiation)
+      : _excludedInstantiation(std::move(excludedInstantiation))
+    {}
+
+    std::unique_ptr<Base> clone () const override
+    {
+      return std::make_unique<ExcludedInstantiation>(*this);
+    }
+
+    bool satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override;
+    std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const override;
+    std::ostream &describe (std::ostream &os) const override;
+    bool operator== (const Arbiter::Base &other) const override;
+    size_t hash () const noexcept override;
 };
 
 } // namespace Requirement

--- a/src/Resolver.h
+++ b/src/Resolver.h
@@ -8,6 +8,8 @@
 
 #include "Dependency.h"
 #include "Graph.h"
+#include "Instantiation.h"
+#include "Project.h"
 #include "Stats.h"
 #include "Types.h"
 #include "Version.h"
@@ -38,18 +40,18 @@ struct ArbiterResolver final : public Arbiter::Base
     ArbiterResolver &operator= (const ArbiterResolver &) = delete;
 
     /**
-     * Fetches the list of dependencies for the given project and version.
+     * Fetches the dependencies for the given project and version.
      *
-     * Returns the dependency list or throws an exception.
+     * Returns the dependencies or throws an exception.
      */
-    ArbiterDependencyList fetchDependencies (const ArbiterProjectIdentifier &project, const ArbiterSelectedVersion &version) noexcept(false);
+    const Arbiter::Instantiation::Dependencies &fetchDependencies (const ArbiterProjectIdentifier &projectIdentifier, const ArbiterSelectedVersion &version) noexcept(false);
 
     /**
-     * Fetches the list of available versions for the given project.
+     * Fetches the available versions for the given project.
      *
-     * Returns the version list or throws an exception.
+     * Returns the versions or throws an exception.
      */
-    ArbiterSelectedVersionList fetchAvailableVersions (const ArbiterProjectIdentifier &project) noexcept(false);
+    const Arbiter::Project::Domain &fetchAvailableVersions (const ArbiterProjectIdentifier &projectIdentifier) noexcept(false);
 
     /**
      * Fetches a selected version for the given metadata string.
@@ -78,8 +80,7 @@ struct ArbiterResolver final : public Arbiter::Base
     const ArbiterResolvedDependencyGraph _initialGraph;
     const ArbiterDependencyList _dependenciesToResolve;
 
-    std::unordered_map<ArbiterResolvedDependency, ArbiterDependencyList> _cachedDependencies;
-    std::unordered_map<ArbiterProjectIdentifier, ArbiterSelectedVersionList> _cachedAvailableVersions;
+    std::unordered_map<ArbiterProjectIdentifier, Arbiter::Project> _projects;
 
     void startStats ();
     void endStats ();


### PR DESCRIPTION
No functional changes yet, but I found this helpful to split out of #92, since it’s just a change in data representation.

Results in a minor space saving at the expense of more lookups.